### PR TITLE
Update GitHub Actions workflow to use GitHub-hosted runner

### DIFF
--- a/.github/workflows/daily_post.yml
+++ b/.github/workflows/daily_post.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   post:
-    runs-on: self-hosted    # Using GitHub-hosted runner instead of self-hosted
+    runs-on: ubuntu-latest    # Using GitHub-hosted runner instead of self-hosted
     
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Changed the runner in the daily_post workflow from self-hosted to GitHub-hosted (ubuntu-latest).
- This update enhances the automation and reliability of the daily posting process.