### PR TITLE
Update daily_post workflow schedule to run every 10 minutes

### DIFF
--- a/.github/workflows/daily_post.yml
+++ b/.github/workflows/daily_post.yml
@@ -2,7 +2,7 @@ name: Daily Telegram Post
 
 on:
   schedule:
-    - cron: '*/1 * * * *'  # Runs at 8:00 UTC daily
+    - cron: '*/10 * * * *'  # Runs at 8:00 UTC daily
   workflow_dispatch:      # Allows manual trigger
   push:
     branches: [ main ]    # Triggers on push to main branch


### PR DESCRIPTION
- Changed the cron schedule in the daily_post.yml workflow from every minute to every 10 minutes for improved efficiency.
- This adjustment helps reduce unnecessary load while maintaining regular posting to Telegram.